### PR TITLE
Fixed a race condition that can lead to a NPE.

### DIFF
--- a/src/main/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapter.java
+++ b/src/main/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapter.java
@@ -109,7 +109,6 @@ public class MesosToSchedulerDriverAdapter implements
 
     private synchronized void subscribe(ExponentialBackOff backOff) throws IOException {
         if (state == State.SUBSCRIBED || state == State.DISCONNECTED) {
-            LOGGER.debug("Cancelling subscriber. As we are in state: {}", state);
             cancelSubscriber();
             return;
         }
@@ -142,7 +141,7 @@ public class MesosToSchedulerDriverAdapter implements
     private synchronized void performReliableSubscription() {
         // If timer is not running, initialize it.
         if (subscriberTimer == null) {
-            LOGGER.info("Initializing reliable subscriber...");
+            LOGGER.info("Initializing reliable subscriber");
             subscriberTimer = createTimerInternal();
             ExponentialBackOff backOff = new ExponentialBackOff.Builder()
                     .setMaxElapsedTimeMillis(Integer.MAX_VALUE /* Try forever */)
@@ -355,12 +354,13 @@ public class MesosToSchedulerDriverAdapter implements
     }
 
     private synchronized void cancelHeartbeatTimer() {
+        if (heartbeatTimer == null) {
+            return;
+        }
+
         LOGGER.info("Cancelling heartbeat timer upon disconnection");
 
-        // Cancel previous heartbeat timer if one exists.
-        if (heartbeatTimer != null) {
-            heartbeatTimer.shutdownNow();
-        }
+        heartbeatTimer.shutdownNow();
 
         heartbeatTimer = null;
         heartbeatTimeout = null;
@@ -720,8 +720,14 @@ public class MesosToSchedulerDriverAdapter implements
     }
 
     private synchronized void cancelSubscriber() {
-        LOGGER.info("Cancelling subscriber...");
+        if (subscriberTimer == null) {
+            return;
+        }
+
+        LOGGER.info("Cancelling subscriber");
+
         subscriberTimer.shutdownNow();
+
         subscriberTimer = null;
     }
 

--- a/src/test/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapterTest.java
+++ b/src/test/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapterTest.java
@@ -344,6 +344,10 @@ public class MesosToSchedulerDriverAdapterTest {
                         driver.received(mesos, subscribedEvent);
 
                         driver.disconnected(mesos);
+
+                        // Ensure that any subsequent subscription retries do not result in an
+                        // additional invocation of `send()` once disconnected.
+                        callback.run();
                         return null;
                     }
                     return null;


### PR DESCRIPTION
The following course of events can lead to a crash:
- Scheduler gets connected with the master.
- Scheduler gets subscribed with the master. We cancel the subscribe timer.
  Note that now subscriberTimer is set to null.
- Scheduler gets disconnected with the master. We again try to invoke
  cancelSubscriber() and invoke subscriberTimer.shutdown() and it crashes
  as expected with a NPE.

Related: https://github.com/mesosphere/mesos-http-adapter/issues/8