### PR TITLE
Made the adapter abort on receiving an ERROR event.

### DIFF
--- a/src/main/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapter.java
+++ b/src/main/java/com/mesosphere/mesos/http-adapter/MesosToSchedulerDriverAdapter.java
@@ -273,6 +273,10 @@ public class MesosToSchedulerDriverAdapter implements
 
             case ERROR: {
                 wrappedScheduler.error(this, event.getError().getMessage());
+
+                // Abort the adapter once the error callback is invoked similar to
+                // the native scheduler driver.
+                abort();
                 break;
             }
 


### PR DESCRIPTION
This is consistent with the native scheduler driver that aborts
after invoking the `error()` callback on the scheduler.